### PR TITLE
Update vue-events version

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "accounting": "^0.4.1",
     "moment": "^2.17.1",
     "vue": "^2.1.0",
-    "vue-events": "vue-2.x",
+    "vue-events": "^3.0.1",
     "vuetable-2": "^1.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
I fixed a bug in `vue-events` that was introduced in `Vue 2.2.x`, just updating this projects dependency.

https://github.com/cklmercer/vue-events/issues/8